### PR TITLE
add catch blocks to fetch promise

### DIFF
--- a/src/Fontello.js
+++ b/src/Fontello.js
@@ -52,6 +52,9 @@ class Fontello {
 				this._session = session
 				return session
 			})
+			.catch(error => {
+				console.error(error)
+			})
 	}
 
 	/**
@@ -81,6 +84,9 @@ class Fontello {
 						.on("error", err => reject(err))
 						.on("close", () => resolve(assets))
 				})
+			})
+			.catch(error => {
+				console.error(error)
 			})
 	}
 


### PR DESCRIPTION
A network error causes a `UnhandledPromiseRejectionWarning` - adding these catch blocks prevents a node exit on webpack compile.