### PR TITLE
Use "deep" assignment for plugin options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ function getPublicPath(compilation) {
 
 class FontelloPlugin {
 	constructor(options) {
-		this.options = Object.assign({}, defaults, options)
+		this.options = _.defaultsDeep({}, defaults, options)
 		this.chunk = new Chunk(this.options.name)
 		this.chunk.ids = []
 		this.chunk.name = this.options.name

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ function getPublicPath(compilation) {
 
 class FontelloPlugin {
 	constructor(options) {
-		this.options = _.defaultsDeep({}, defaults, options)
+		this.options = _.defaultsDeep({}, options, defaults)
 		this.chunk = new Chunk(this.options.name)
 		this.chunk.ids = []
 		this.chunk.name = this.options.name


### PR DESCRIPTION
This makes it possible to only specify output.css or output.font instead of both