### PR TITLE
Update for Webpack 4

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ class FontelloPlugin {
 					}
 				})
 				.then(() => cb())
-			compilation.plugin("html-webpack-plugin-before-html-generation", (data, cb) => {
+			compilation.hooks.htmlWebpackPluginBeforeHtmlProcessing.tapAsync('FontellowWebpackPlugin', (data, cb) => {
 				console.log(getPublicPath(compilation))
 				data.assets.css.push(getPublicPath(compilation) + cssFile)
 				cb(null, data)


### PR DESCRIPTION
The hook system in webpack4 changed a bit, this makes it work again (previously would spew out "attempt to call cb (undefined)")